### PR TITLE
Add governance contracts

### DIFF
--- a/contracts/ArrowGovernor.sol
+++ b/contracts/ArrowGovernor.sol
@@ -1,0 +1,116 @@
+pragma solidity ^0.8.0;
+
+// SPDX-License-Identifier: MIT
+
+import "@openzeppelin/contracts/governance/Governor.sol";
+import "@openzeppelin/contracts/governance/compatibility/GovernorCompatibilityBravo.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol";
+
+/**
+    @title Arrow Governor implementation
+
+    This contract is responsible for managing new proposals and votes submitted to the ArrowTreasury.
+
+    When deployed, this should be added as the sole proposer role to the ArrowTreasury.
+ */
+contract ArrowGovernor is Governor, GovernorCompatibilityBravo, GovernorVotes, GovernorVotesQuorumFraction, GovernorTimelockControl {
+    constructor(ERC20Votes token, TimelockController timelock)
+        Governor("ArrowGovernor")
+        GovernorVotes(token)
+        GovernorVotesQuorumFraction(4)
+        GovernorTimelockControl(timelock)
+    {}
+
+    /**
+        Defines the delay between when a new proposal is created and when it becomes eligible for voting.
+     */
+    function votingDelay() public pure virtual override returns (uint256) {
+        return 6575; // 1 day
+    }
+
+    /**
+        Defines the length of the period of voting before a proposal is marked as a success or failure. 
+     */
+    function votingPeriod() public pure virtual override returns (uint256) {
+        return 46027; // 1 week
+    }
+
+    /**
+        Defines the number of arrow tokens required to create a new proposal.
+     */
+    function proposalThreshold() public pure override returns (uint256) {
+        return 1000; // 1000 ARROW tokens are needed to submit a new proposal.
+    }
+
+    // The functions below are overrides required by Solidity.
+
+    function quorum(uint256 blockNumber)
+        public
+        view
+        override(IGovernor, GovernorVotesQuorumFraction)
+        returns (uint256)
+    {
+        return super.quorum(blockNumber);
+    }
+
+    function getVotes(address account, uint256 blockNumber)
+        public
+        view
+        override(IGovernor, GovernorVotes)
+        returns (uint256)
+    {
+        return super.getVotes(account, blockNumber);
+    }
+
+    function state(uint256 proposalId)
+        public
+        view
+        override(Governor, IGovernor, GovernorTimelockControl)
+        returns (ProposalState)
+    {
+        return super.state(proposalId);
+    }
+
+    function propose(address[] memory targets, uint256[] memory values, bytes[] memory calldatas, string memory description)
+        public
+        override(Governor, GovernorCompatibilityBravo, IGovernor)
+        returns (uint256)
+    {
+        return super.propose(targets, values, calldatas, description);
+    }
+
+    function _execute(uint256 proposalId, address[] memory targets, uint256[] memory values, bytes[] memory calldatas, bytes32 descriptionHash)
+        internal
+        override(Governor, GovernorTimelockControl)
+    {
+        super._execute(proposalId, targets, values, calldatas, descriptionHash);
+    }
+
+    function _cancel(address[] memory targets, uint256[] memory values, bytes[] memory calldatas, bytes32 descriptionHash)
+        internal
+        override(Governor, GovernorTimelockControl)
+        returns (uint256)
+    {
+        return super._cancel(targets, values, calldatas, descriptionHash);
+    }
+
+    function _executor()
+        internal
+        view
+        override(Governor, GovernorTimelockControl)
+        returns (address)
+    {
+        return super._executor();
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(Governor, IERC165, GovernorTimelockControl)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/ArrowToken.sol
+++ b/contracts/ArrowToken.sol
@@ -3,12 +3,38 @@ pragma solidity ^0.8.0;
 // SPDX-License-Identifier: MIT
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 
 /**
     @title Arrow Token implementation
  */
-contract ArrowToken is ERC20 {
-    constructor(uint256 initialSupply) ERC20("Arrow", "ARROW") {
+contract ArrowToken is ERC20, ERC20Permit, ERC20Votes {
+    constructor(uint256 initialSupply)
+        ERC20("Arrow", "ARROW")
+        ERC20Permit("Arrow")
+    {
         _mint(msg.sender, initialSupply);
+    }
+
+    function _afterTokenTransfer(address from, address to, uint256 amount)
+        internal
+        override(ERC20, ERC20Votes)
+    {
+        super._afterTokenTransfer(from, to, amount);
+    }
+
+    function _mint(address to, uint256 amount)
+        internal
+        override(ERC20, ERC20Votes)
+    {
+        super._mint(to, amount);
+    }
+
+    function _burn(address account, uint256 amount)
+        internal
+        override(ERC20, ERC20Votes)
+    {
+        super._burn(account, amount);
     }
 }

--- a/contracts/ArrowTreasury.sol
+++ b/contracts/ArrowTreasury.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.8.0;
+
+// SPDX-License-Identifier: MIT
+
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+
+/**
+    @title Arrow Treasury implementation
+
+    This contract is responsible for holding funds and executing proposals submitted to the ArrowGovernor contract.
+ */
+contract ArrowTreasury is TimelockController {
+
+    constructor(uint256 minDelay, address[] memory proposers, address[] memory executors)
+        TimelockController(minDelay, proposers, executors) {}
+}

--- a/contracts/mocks/MockArrowGovernor.sol
+++ b/contracts/mocks/MockArrowGovernor.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.8.0;
+
+// SPDX-License-Identifier: MIT
+
+import "../ArrowGovernor.sol";
+
+contract MockArrowGovernor is ArrowGovernor {
+    constructor(ERC20Votes token, TimelockController timelock)
+        ArrowGovernor(token, timelock) {}
+
+    // Shorten delays for testing purposes.
+
+    function votingDelay() public pure override returns (uint256) {
+        return 2;
+    }
+
+    function votingPeriod() public pure override returns (uint256) {
+        return 3;
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import pytest
-
+from brownie import Contract, interface
 
 @pytest.fixture(scope="function", autouse=True)
 def isolate(fn_isolation):
@@ -9,7 +9,26 @@ def isolate(fn_isolation):
     # https://eth-brownie.readthedocs.io/en/v1.10.3/tests-pytest-intro.html#isolation-fixtures
     pass
 
+@pytest.fixture(scope="module")
+def admin(accounts):
+    return accounts[0]
 
 @pytest.fixture(scope="module")
-def token(ArrowToken, accounts):
-    return ArrowToken.deploy(1e21, {'from': accounts[0]})
+def token(ArrowToken, admin):
+    return ArrowToken.deploy(1e21, {'from': admin})
+
+@pytest.fixture(scope="module")
+def treasury(ArrowTreasury, admin):
+    return ArrowTreasury.deploy(3, [], [], {'from': admin})
+
+@pytest.fixture(scope="module")
+def governor(MockArrowGovernor, token, admin, treasury):
+
+    governor = MockArrowGovernor.deploy(token, treasury, {'from': admin})
+
+    treasury.grantRole(treasury.PROPOSER_ROLE(), governor)
+    treasury.grantRole(treasury.EXECUTOR_ROLE(), "0x0000000000000000000000000000000000000000")
+    treasury.revokeRole(treasury.TIMELOCK_ADMIN_ROLE(), admin)
+
+    return governor
+    

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -1,0 +1,149 @@
+
+import pytest
+
+import brownie
+
+from brownie import web3
+
+def test_new_proposal(chain, token, governor, treasury, accounts, admin):
+
+    payee_account = accounts[1]
+    amount = 1000000
+    description = "Proposal: Grant Payee"
+
+    assert token.balanceOf(payee_account) == 0
+
+    # Load treasury with ARROW.
+    token.transfer(treasury, amount, {"from": admin})
+
+    assert token.balanceOf(treasury) == amount
+
+    # Delegate voting power to self before vote.
+    token.delegate(admin, {"from": admin})
+
+    # Create a proposal.
+    proposal_calldata = token.transfer.encode_input(payee_account, amount)
+
+    proposal_id = governor.propose(
+        [token],
+        [0],
+        [proposal_calldata],
+        description
+    ).return_value
+
+    # Wait until the proposal becomes active.
+    chain.mine(governor.votingDelay())
+
+    # Cast 100% votes to succeed.
+    governor.castVote(proposal_id, True, {"from": admin})
+
+    # Wait for voting period to end.
+    chain.mine(governor.votingPeriod())
+
+    # Execute the proposal.
+    description_hash = web3.keccak(text=description)
+
+    governor.queue(
+        [token],
+        [0],
+        [proposal_calldata],
+        description_hash,
+    )
+
+    chain.sleep(treasury.getMinDelay())
+
+    governor.execute(
+        [token],
+        [0],
+        [proposal_calldata],
+        description_hash,
+    )
+
+    # Treasury should have transferred funds to payee.
+    assert token.balanceOf(payee_account) == amount
+    assert token.balanceOf(treasury) == 0
+
+def test_treasury_alterations(chain, treasury, governor, accounts, admin, token):
+
+    # New admin should not have access control by default.
+    potential_admin = accounts[1]
+
+    assert treasury.hasRole(treasury.TIMELOCK_ADMIN_ROLE(), potential_admin) == False
+
+    # Access control alterations should not be able to bypass governance.
+    with brownie.reverts():
+        treasury.grantRole(treasury.TIMELOCK_ADMIN_ROLE(), potential_admin, {"from": potential_admin})
+
+    # Delegate voting power to self before vote.
+    token.delegate(admin, {"from": admin})
+
+    # Create a proposal to add access.
+    proposal_calldata = treasury.grantRole.encode_input(treasury.TIMELOCK_ADMIN_ROLE(), potential_admin)
+    description = "Grant new admin"
+
+    proposal_id = governor.propose(
+        [treasury],
+        [0],
+        [proposal_calldata],
+        description
+    ).return_value    
+
+    # Wait until the proposal becomes active.
+    chain.mine(governor.votingDelay())
+
+    # Cast 100% votes to succeed.
+    governor.castVote(proposal_id, True, {"from": admin})
+
+    # Wait for voting period to end.
+    chain.mine(governor.votingPeriod())
+
+    # Execute the proposal.
+    description_hash = web3.keccak(text=description)
+
+    governor.queue(
+        [treasury],
+        [0],
+        [proposal_calldata],
+        description_hash
+    )
+
+    chain.sleep(treasury.getMinDelay())
+
+    governor.execute(
+        [treasury],
+        [0],
+        [proposal_calldata],
+        description_hash
+    )
+
+    assert treasury.hasRole(treasury.TIMELOCK_ADMIN_ROLE(), potential_admin) == True
+
+def test_proposal_without_tokens(treasury, governor, token, accounts, admin):
+
+    # A proposer with no tokens should not be able to submit a new governance proposal.
+    proposer = accounts[1]
+
+    assert token.balanceOf(proposer) == 0
+
+    proposal_calldata = token.transfer.encode_input(proposer, 1000)
+
+    with brownie.reverts("GovernorCompatibilityBravo: proposer votes below proposal threshold"):
+        governor.propose(
+            [token],
+            [0],
+            [proposal_calldata],
+            "New Proposal",
+            {"from": proposer}
+        ) 
+
+    # A proposer with delegated tokens should be able to submit a new governance proposal.
+    token.transfer(proposer, governor.proposalThreshold(), {"from": admin})
+    token.delegate(proposer, {"from": proposer})
+
+    governor.propose(
+        [token],
+        [0],
+        [proposal_calldata],
+        "New Proposal",
+        {"from": proposer}
+    )


### PR DESCRIPTION
This changeset adds the required governance contracts to manage proposals submitted by the Arrow DAO.

I've made some fairly arbitrary decisions:

- The delay between proposals being submitted and becoming eligible for voting is 1 day
- The delay between votes opening and closing is 1 week
- Proposers of new proposals must own at least 1000 ARROW tokens in their account

Those seem reasonable but happy to change any of them based on consensus.

As always, critical feedback warmly encouraged.
