### PR TITLE
Add minting functionality to token

### DIFF
--- a/contracts/ArrowToken.sol
+++ b/contracts/ArrowToken.sol
@@ -2,13 +2,26 @@ pragma solidity ^0.8.0;
 
 // SPDX-License-Identifier: MIT
 
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 /**
     @title Arrow Token implementation
  */
-contract ArrowToken is ERC20 {
-    constructor(uint256 initialSupply) ERC20("Arrow", "ARROW") {
+contract ArrowToken is ERC20, Ownable {
+    constructor(uint256 initialSupply)
+        ERC20("Arrow", "ARROW")
+    {
         _mint(msg.sender, initialSupply);
+    }
+
+    /**
+        Mints new tokens.
+
+        Only accepts calls from the contract owner.
+     */
+    function mint(address to, uint256 amount) public onlyOwner
+    {
+        _mint(to, amount);
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,3 +13,7 @@ def isolate(fn_isolation):
 @pytest.fixture(scope="module")
 def token(ArrowToken, accounts):
     return ArrowToken.deploy(1e21, {'from': accounts[0]})
+
+@pytest.fixture(scope="module")
+def admin(accounts):
+    return accounts[0]

--- a/tests/test_minting.py
+++ b/tests/test_minting.py
@@ -1,0 +1,42 @@
+import pytest
+import brownie
+
+def test_mint(token, admin, accounts):
+    
+    # By default, the admin (deployer) account can mint tokens.
+    amount = 1000
+
+    amount_before = token.balanceOf(admin)
+
+    token.mint(admin, amount, {"from": admin})
+
+    amount_after = token.balanceOf(admin)
+
+    assert amount_after - amount_before == amount
+
+    # No other address can mint.
+    with brownie.reverts("Ownable: caller is not the owner"):
+        token.mint(accounts[1], amount, {"from": accounts[1]})
+
+    assert token.balanceOf(accounts[1]) == 0
+
+def test_mint_new_owner(token, admin, accounts):
+
+    amount = 1000
+    new_owner = accounts[1]
+
+    # Transfer contract ownership.
+    token.transferOwnership(new_owner)
+
+    # Old owner should not be able to mint tokens.
+    with brownie.reverts("Ownable: caller is not the owner"):
+        token.mint(admin, amount, {"from": admin})
+
+    # New owner should be able to mint tokens.
+    amount_before = token.balanceOf(new_owner)
+
+    token.mint(new_owner, amount, {"from": new_owner})
+
+    amount_after = token.balanceOf(new_owner)
+
+    assert amount_after - amount_before == amount


### PR DESCRIPTION
This changeset adds a permissioned minting function to the ArrowToken contract, which allows the contract owner to mint new tokens.

Only the address owning the token contract is permitted to mint new tokens.