### PR TITLE
Add vesting wallet implementation

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -1,6 +1,7 @@
 
 dependencies:
   - OpenZeppelin/openzeppelin-contracts@4.4.1
+  - OpenZeppelin/openzeppelin-contracts-upgradeable@4.4.1
 
 # path remapping to support imports from GitHub/NPM
 compiler:
@@ -8,3 +9,4 @@ compiler:
     version: 0.8.11
     remappings:
       - "@openzeppelin=OpenZeppelin/openzeppelin-contracts@4.4.1"
+      - "@openzeppelin-upgradeable=OpenZeppelin/openzeppelin-contracts-upgradeable@4.4.1"

--- a/contracts/ArrowVestingBase.sol
+++ b/contracts/ArrowVestingBase.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.8.0;
+
+// SPDX-License-Identifier: MIT
+
+import "@openzeppelin-upgradeable/contracts/finance/VestingWalletUpgradeable.sol";
+
+/**
+    Base implementation of vesting contract that will be cloned into individual vesting wallets pointing at specific beneficiary addresses.
+ */
+contract ArrowVestingBase is VestingWalletUpgradeable {
+
+    constructor() initializer {}
+
+    function initialize(
+        address beneficiaryAddress,
+        uint64 startTimestamp,
+        uint64 durationSeconds
+    ) public initializer {
+        __VestingWallet_init(beneficiaryAddress, startTimestamp, durationSeconds);
+    } 
+}

--- a/contracts/ArrowVestingFactory.sol
+++ b/contracts/ArrowVestingFactory.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.8.0;
+
+// SPDX-License-Identifier: MIT
+
+import "@openzeppelin/contracts/proxy/Clones.sol";
+import "./ArrowVestingBase.sol";
+
+/**
+    Factory contract for creating vesting wallets from their base implementations.
+ */
+contract ArrowVestingFactory {
+
+    address immutable vestingImplementation;
+
+    constructor() public {
+        vestingImplementation = address(new ArrowVestingBase());
+    }
+
+    /**
+        Creates a new cloned vesting wallet from its base implementation.
+
+        The wallet will initially be empty and should have appropriate ERC20 tokens and ETH transferred to it after creation.
+     */
+    function createVestingSchedule(
+        address beneficiaryAddress,
+        uint64 startTimestamp,
+        uint64 durationSeconds
+    ) external returns (address) {
+        address clone = Clones.clone(vestingImplementation);
+        ArrowVestingBase(payable(clone)).initialize(beneficiaryAddress, startTimestamp, durationSeconds);
+        return clone;
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,8 @@ def token(ArrowToken, accounts):
 @pytest.fixture(scope="module")
 def admin(accounts):
     return accounts[0]
+
+@pytest.fixture(scope="module")
+def vestingFactory(ArrowVestingFactory, token, accounts):
+    return ArrowVestingFactory.deploy({'from': accounts[0]})
+

--- a/tests/test_vesting.py
+++ b/tests/test_vesting.py
@@ -1,0 +1,118 @@
+
+import pytest
+
+import brownie
+from brownie import Contract
+
+def test_vesting(ArrowVestingBase, chain, token, vestingFactory, accounts):
+
+    beneficiary = accounts[1]
+    startTimestamp = chain.time() + 100
+    durationSeconds = 100
+    amount = 1000
+
+    # Create a new vesting schedule.
+    vestingWalletTx = vestingFactory.createVestingSchedule(beneficiary, startTimestamp, durationSeconds)
+    vestingContract = ArrowVestingBase.at(vestingWalletTx.return_value)
+
+    # Add tokens to the contract.
+    token.transfer(vestingContract, amount)
+
+    assert token.balanceOf(vestingContract) == amount
+
+    # Check contract variables have been set correctly.
+    assert vestingContract.start() == startTimestamp
+    assert vestingContract.duration() == durationSeconds
+    assert vestingContract.released(token) == 0
+
+    # No tokens should have been immediately released.
+    assert token.balanceOf(beneficiary) == 0
+
+    vestingContract.release(token, {"from": beneficiary})
+
+    assert token.balanceOf(beneficiary) == 0
+
+    # No tokens should have been released before the end of the vesting cliff.
+    chain.mine(1, timestamp=startTimestamp)
+    tx = vestingContract.release(token, {"from": beneficiary})
+
+    assert token.balanceOf(beneficiary) == amount * (tx.timestamp - startTimestamp) / durationSeconds
+
+    # Half the tokens should be vested when half the vesting duration has elapsed.
+    chain.mine(1, timestamp=(startTimestamp + int(durationSeconds / 2)))
+    tx = vestingContract.release(token, {"from": beneficiary})
+
+    assert token.balanceOf(beneficiary) == amount * (tx.timestamp - startTimestamp) / durationSeconds
+
+    # All tokens should be vested when the vesting duration has elapsed.
+    chain.mine(1, timestamp=(startTimestamp + durationSeconds))
+    vestingContract.release(token, {"from": beneficiary})
+
+    assert token.balanceOf(beneficiary) == amount    
+
+def test_multiple_vestings(ArrowVestingBase, chain, token, vestingFactory, accounts):
+
+    # Create multiple vesting contracts.
+    beneficiaryOne = accounts[1]
+    startTimestampOne = chain.time() + 200
+    durationOne = 100
+    amountOne = 1000
+
+    tx = vestingFactory.createVestingSchedule(beneficiaryOne, startTimestampOne, durationOne)
+    vestingOne = ArrowVestingBase.at(tx.return_value)
+
+    beneficiaryTwo = accounts[2]
+    startTimestampTwo = chain.time() + 250
+    durationTwo = 200
+    amountTwo = 2000
+
+    tx = vestingFactory.createVestingSchedule(beneficiaryTwo, startTimestampTwo, durationTwo)
+    vestingTwo = ArrowVestingBase.at(tx.return_value)
+
+    assert token.balanceOf(beneficiaryOne) == 0
+    assert token.balanceOf(beneficiaryTwo) == 0
+
+    # Load contracts with tokens.
+    token.transfer(vestingOne, amountOne)
+    token.transfer(vestingTwo, amountTwo)
+
+    assert token.balanceOf(vestingOne) == amountOne
+    assert token.balanceOf(vestingTwo) == amountTwo
+
+    # Release should vest no tokens before start.
+    chain.mine(1, timestamp=startTimestampOne)
+
+    vestingOne.release(token, {"from": beneficiaryOne})
+    vestingTwo.release(token, {"from": beneficiaryTwo})
+
+    assert token.balanceOf(beneficiaryOne) == 0
+    assert token.balanceOf(beneficiaryTwo) == 0
+
+    # Token releases should occur at appropriate times.
+    
+    # Start of first vesting.
+    chain.mine(1, timestamp=startTimestampTwo)
+
+    txOne = vestingOne.release(token, {"from": beneficiaryOne})
+    txTwo = vestingTwo.release(token, {"from": beneficiaryTwo})
+
+    assert token.balanceOf(beneficiaryOne) == amountOne * ((txOne.timestamp - startTimestampOne) / durationOne)
+    assert token.balanceOf(beneficiaryTwo) == amountTwo * ((txTwo.timestamp - startTimestampTwo) / durationTwo)
+
+    ## End of first vesting.
+    chain.mine(1, timestamp=startTimestampOne + durationOne)
+
+    txOne = vestingOne.release(token, {"from": beneficiaryOne})
+    txTwo = vestingTwo.release(token, {"from": beneficiaryTwo})
+
+    assert token.balanceOf(beneficiaryOne) == amountOne
+    assert token.balanceOf(beneficiaryTwo) == amountTwo * ((txTwo.timestamp - startTimestampTwo) / durationTwo)
+
+    ## End of second vesting.
+    chain.mine(1, timestamp=startTimestampTwo + durationTwo)
+
+    vestingOne.release(token, {"from": beneficiaryOne})
+    vestingTwo.release(token, {"from": beneficiaryTwo})
+
+    assert token.balanceOf(beneficiaryOne) == amountOne
+    assert token.balanceOf(beneficiaryTwo) == amountTwo


### PR DESCRIPTION
This adds a vesting wallet implementation based on the OpenZeppelin upgradeable VestingWallet, and a factory contract that creates cloned instances of the base implementation contract for gas optimisation.

The approach of cloning a base implementation, rather than naively deploying a new contract copy on every factory call, reduces gas costs by more than 4x:

```
Gas Costs (wei)
---
Naive Deployment:    638726
Cloned Deployment:   135756
``` 

Resolves #4.