### PR TITLE
Add deployment script and process

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,44 @@ To run the tests:
 brownie test
 ```
 
+## Deploying
+
+To deploy contracts on the Rinkeby testnet:
+
+1. Generate a new deployment account.
+
+```
+brownie accounts generate deployment_account
+```
+
+2. Set up an [Infura development account](https://blog.infura.io/getting-started-with-infura-28e41844cc89/) and generate a PROJECT_ID.
+
+3. Export the PROJECT_ID into your local environment.
+
+```
+export WEB3_INFURA_PROJECT_ID=<PROJECT_ID>
+```
+
+4. Load enough ETH into your deployment account for contract deployments to succeed.
+
+5. Run the deployment script.
+
+```
+brownie run scripts/deploy.py --network rinkeby
+```
+
+6. Sign up for an Etherscan account, generate an API token, and export it into your local environment.
+
+```
+export ETHERSCAN_TOKEN=<ETHERSCAN API TOKEN>
+```
+
+7. Publish contract sources to Etherscan.
+
+
+Mainnet deployments can proceed by following the same steps, replacing `--network rinkeby` with `--network mainnet`.
+
+
 ## Deployments
 
 ### Rinkeby
@@ -21,6 +59,8 @@ brownie test
 | Contract | Address |
 | -- | -- |
 | Gnosis Safe | 0x6943eBEfCD7d85B536aEb35BBFd95C5699158Abe |
+| ArrowToken | 0x49eD1A01Ed28E1d0E165C85726e8c109A49e4E77 | 
+| ArrowVestingFactory | 0x705B85358071f32B282483556778E375Fc530650 |
 
 ## License
 

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+from brownie import ArrowToken, ArrowVestingFactory, accounts
+
+
+def main(account = None):
+
+    # Unlock the deployment address if none is supplied.
+    if not account: 
+        account = accounts.load("deployment_account")
+
+    # Deploy token contract.
+    token_initial_supply = 1e21
+
+    token_contract = ArrowToken.deploy(token_initial_supply, {'from': account})
+
+    print(f"Deployed token contract at {token_contract} with {token_initial_supply} supply.")
+    print(f"Current contract owner: {token_contract.owner()}. This address currently controls minting capabilities.\n")
+
+    ## Publish source if possible.
+    try:
+        ArrowToken.publish_source(token_contract, {'from': account})
+    except:
+        print("WARNING: contract source not published to Etherscan.")
+
+    # Deploy vesting contracts.
+    vesting_factory = ArrowVestingFactory.deploy({'from': account})
+
+    print(f"Deployed vesting factory at {vesting_factory}.\n")
+
+    ## Publish source if possible.
+    try:
+        ArrowVestingFactory.publish_source(vesting_factory, {'from': account})
+    except:
+        print("WARNING: contract source not published to Etherscan.")

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,0 +1,20 @@
+import pytest
+
+import scripts.deploy as deploy
+
+def test_deployment(ArrowToken, ArrowVestingFactory, accounts, history):
+    
+    # Run the deployment script.
+    deployment_account = accounts[1]
+    
+    deploy.main(deployment_account)
+
+    # Contracts should have been deployed.
+    vesting_contract = ArrowVestingFactory.at(history[-1].contract_address)
+    token_contract = ArrowToken.at(history[-2].contract_address)
+
+    # Deployment account should be owner of the token contract.
+    assert token_contract.owner() == deployment_account
+    
+    # All minted tokens should have been sent to deployment account.
+    assert token_contract.balanceOf(deployment_account) == 1e21


### PR DESCRIPTION
Contains the deployment script and tests.

Also contains step by step instructions of how to deploy in README. 

Deployed Rinkeby contract addresses are also defined in the Deployments section.

The total number of ARROW tokens that should be deployed should probably be discussed. Do we want 1E21 tokens? More? Less? It's possible to mint more but we should probably come up with a sensible default to start off with.