### PR TITLE
allow for localhost deployment; clean-up of the deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ npm run test
 
 ## Deployments
 
+To deploy on the Optimism Kovan testnet:
+
+```bash
+npm run deployOptimismKovan
+```
+
+To deploy on `localhost`:
+
+```bash
+npx hardhat node
+npx hardhat run --network localhost deploy/deployArrowTokenHot.js
+```
+
 ### Rinkeby
 
 | Contract    | Address                                    |

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,17 +1,44 @@
 require("dotenv").config();
-require("hardhat-deploy");
 require("@nomiclabs/hardhat-web3");
 require("@nomiclabs/hardhat-etherscan");
 require("@nomiclabs/hardhat-ethers");
+require("@nomiclabs/hardhat-waffle");
 require("@openzeppelin/hardhat-upgrades");
 
-// Helpful plugins:
-// require("@nomiclabs/hardhat-waffle");
+const adminKey = process.env.ADMIN_KEY || "";
+const etherscanOptimismAPI = process.env.ETHERSCAN_API_OPTIMISM || "";
 
+function createNetworkConfig() {
+  if (adminKey) {
+    return {
+      optimismKovan: {
+        url: "https://kovan.optimism.io/",
+        // ovm: true, // NOTE: example of how you could use a custom compiler
+        gasPrice: 10000,
+        chainId: 69,
+        // Account specifics for testing
+        accounts: [
+          process.env.ADMIN_KEY,
+        ],
+        timeout: 40000,
+      },
+    };
+  } else {
+    return {};
+  }
+}
+
+const networkConfig = createNetworkConfig();
 /**
  * @type import('hardhat/config').HardhatUserConfig
  */
 module.exports = {
+  paths: {
+    sources: "./contracts",
+    tests: "./test",
+    cache: "./cache",
+    artifacts: "./artifacts",
+  },
   solidity: {
     version: "0.8.11",
     // overrides: {
@@ -25,26 +52,14 @@ module.exports = {
   },
 
   networks: {
-    optimismKovan: {
-      url: "https://kovan.optimism.io/",
-      // ovm: true, // NOTE: example of how you could use a custom compiler
-      gasPrice: 10000,
-      chainId: 69,
-      // Account specifics for testing
-      timeout: 40000,
-    },
+    hardhat: {},
+    ...networkConfig,
   },
   // Easy contract verification
   etherscan: {
     // Your API key for Etherscan
     // Obtain one at https://etherscan.io/
     // apiKey: process.env.ETHERSCAN_API,
-    apiKey: process.env.ETHERSCAN_API_OPTIMISM,
+    apiKey: etherscanOptimismAPI,
   },
-  namedAccounts: {
-    deployer: {
-      default: 0,
-    },
-  },
-  paths: {},
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "npx hardhat test",
     "verifyOptimismKovan": "npx hardhat verify --network optimismKovan",
-    "deployOptimismKovan": "npx hardhat deploy --network optimismKovan"
+    "deployOptimismKovan": "npx hardhat run --network optimismKovan deploy/deployArrowTokenHot.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I have made necessary changes to the deployment script's structure to 
1) reflect the npm deployment script and hardhat config changes so that users can deploy on the localhost, and
2) change the deployment code to allow for deploying upgradeable contracts #19 . I should have made this change in that PR but consider that there's a structural change and to avoid duplicated work, I decided to make this change in this PR

Also updated the readme to inform the capability of deploying on localhost. 

Allowing for localhost deployment speeds up the development/debugging process and avoid cluttering the Koran network with our contracts. 