### PR TITLE
Add tests for upgrade ownership and transfer

### DIFF
--- a/test/upgrade.js
+++ b/test/upgrade.js
@@ -14,7 +14,7 @@ describe("Contract Upgrades", function () {
   let signer2;
   let amountTransferredToSigner1;
 
-  before(async function () {
+  beforeEach(async function () {
     Token = await ethers.getContractFactory("ArrowToken");
     [owner, signer1, signer2] = await ethers.getSigners();
     let name = "Arrow Token";
@@ -34,13 +34,36 @@ describe("Contract Upgrades", function () {
       senderBalance - amountTransferredToSigner1
     );
 
+    // Upgrade token to v2
     TokenV2 = await ethers.getContractFactory("ArrowTokenV2");
+
     arrowTokenV2 = await upgrades.upgradeProxy(arrowToken, TokenV2, {
       call: { fn: "initializeV2", args: [52] },
     });
+    
+    expect(await arrowTokenV2.myVal()).to.equal(52);
+
   });
 
-  describe("Upgrade ArrowToken to ArrowTokenV2", function () {
+  describe("Upgrade ArrowToken", function () {
+
+    it("Should not be upgradable by any account but the owner", async function () {
+      
+      expect(() => upgrades.upgradeProxy(arrowToken, TokenV2.connect(signer1.address), {
+        call: { fn: "initializeV2", args: [52] },
+      })).to.throw("invalid signer");
+
+      // Upgrade should succeed after ownership is transferred.
+      await arrowToken.transferOwnership(signer1.address);
+
+      expect(() => upgrades.upgradeProxy(arrowToken, TokenV2.connect(owner.address), {
+        call: { fn: "initializeV2", args: [52] },
+      })).to.throw("invalid signer");
+
+      expect(() => upgrades.upgradeProxy(arrowToken, TokenV2.connect(signer1.address), {
+        call: { fn: "initializeV2", args: [52] },
+      })).to.not.throw;
+    });
 
     it("V2 should have the same amount of token supplies as the older contract", async function () {
       assert.strictEqual(
@@ -59,14 +82,6 @@ describe("Contract Upgrades", function () {
 
     it("Should have the correct value for state variable `myVal`", async function () {
       assert.strictEqual(await arrowTokenV2.myVal(), 52, "myVal value");
-    });
-
-    it("V2 should be forwarded to by the same proxy contract as V1", async function () {
-      assert.strictEqual(
-        arrowTokenV2.address,
-        arrowToken.address,
-        "contract address"
-      );
     });
 
     it("V2 should be able to mint tokens to self", async function () {
@@ -124,6 +139,12 @@ describe("Contract Upgrades", function () {
       expect(await arrowTokenV2.balanceOf(signer2.address)).to.equal(
         receiverBalance + amount
       );
+    });
+
+    it("Should be able to update multiple times", async function () {
+      expect(() => upgrades.upgradeProxy(arrowTokenV2, TokenV2, {
+        call: { fn: "initializeV2", args: [52] },
+      })).to.not.throw;
     });
   });
 });


### PR DESCRIPTION
This change introduces tests to assert that contracts cannot be
upgraded by any address other than the owner of the contract,
which would cause a large security risk.