### PR TITLE
add more docs to smart contracts

### DIFF
--- a/contracts/ArrowToken.sol
+++ b/contracts/ArrowToken.sol
@@ -8,6 +8,8 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 /**
     @title Arrow Token Implementation
+    @notice This is an upgradeable contract that conforms to the ERC-20 standard
+    @dev Upgrades can be made directly on this contract as versioning will be handled by git. However, one needs to keep any potential storage collisions in mind when introducing new variables/functions
 */
 contract ArrowToken is
     Initializable,
@@ -15,10 +17,17 @@ contract ArrowToken is
     OwnableUpgradeable,
     UUPSUpgradeable
 {
-    // implement the UUPS interface
+    /**
+        @notice Ensures only the owner can upgrade this contract
+        @dev Must be included for the UUPS proxy: https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable
+    */
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
-    /// @custom:oz-upgrades-unsafe-allow constructor
+     /**
+        @notice Makes sure that the contract is initialized
+        @dev Must be included for the UUPS proxy to prevent ownership attacks: https://forum.openzeppelin.com/t/security-advisory-initialize-uups-implementation-contracts/15301
+    */
+    ///@custom:oz-upgrades-unsafe-allow constructor
     constructor() initializer {}
 
     /** 

--- a/contracts/ArrowVestingBase.sol
+++ b/contracts/ArrowVestingBase.sol
@@ -5,8 +5,10 @@ import "@openzeppelin/contracts-upgradeable/finance/VestingWalletUpgradeable.sol
 
 /** 
     @title Base implementation of vesting contract that will be cloned into individual vesting wallets pointing at specific beneficiary addresses.
+    @dev Although the contract inherits an upgradeable interface, the contract itself is not intended to be upgradeable; rather, it is intended to be cloned by `ArrowVestingFactory`.
 */
 contract ArrowVestingBase is VestingWalletUpgradeable {
+
     constructor() initializer {}
 
     function initialize(

--- a/contracts/ArrowVestingFactory.sol
+++ b/contracts/ArrowVestingFactory.sol
@@ -6,9 +6,10 @@ import "@openzeppelin/contracts/proxy/Clones.sol";
 import "./ArrowVestingBase.sol";
 
 /**
-    Factory contract for creating vesting wallets from their base implementations.
+    @title Factory contract for creating vesting wallets from their base implementations
  */
 contract ArrowVestingFactory {
+    
     address public vestingImplementation;
 
     event NewVestingAgreement(
@@ -23,9 +24,11 @@ contract ArrowVestingFactory {
     }
 
     /**
-        Creates a new cloned vesting wallet from its base implementation.
-
-        The wallet will initially be empty and should have appropriate ERC20 tokens and ETH transferred to it after creation.
+        @notice Creates a new cloned vesting wallet from its base implementation. The wallet will initially be empty and should have appropriate ERC20 tokens and ETH transferred to it after creation
+        @param beneficiaryAddress The address of which the vesting is entitled to
+        @param startTimestamp The start time of the vesting schedule
+        @param durationSeconds Denotes the length of the vesting period
+        @return clone The address of the vesting wallet implemented by `ArrowVestingBase`
      */
     function createVestingSchedule(
         address beneficiaryAddress,

--- a/contracts/test/ArrowTokenV2.sol
+++ b/contracts/test/ArrowTokenV2.sol
@@ -20,7 +20,10 @@ contract ArrowTokenV2 is
     // new variable for testing purpose
     uint256 public myVal;
 
-    // implement the UUPS interface
+    /**
+        @notice Ensures only the owner can upgrade this contract
+        @dev Must be included for the UUPS proxy: https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable
+    */
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
     /** 


### PR DESCRIPTION
This PR strives to strengthen the documentation for Arrow smart contracts. We need to try to make it as thorough as possible so that we can automate generating front-end docs later on.

@BrassLion Would need your help on writing docs for `ArrowVestingBase`.