### PR TITLE
Add mainnet deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Upgrading contracts that are owned by a multisig should be proposed using [Defen
 
 ## Deployments
 
+## Mainnet
+
+| Contract            | Address                                    |
+| ------------------- | ------------------------------------------ |
+| Gnosis Safe         | 0x03b5Dc2CE78a7bEe9F66DD619b291595a2E166BB |
+| ArrowToken          | 0x736609D310B5F925531B5ad895925CB0586F6241 |
+| ArrowVestingFactory | 0xe774395857A91f7158FB0a79385c4C9F7975B848 |
+
 ### Rinkeby
 
 | Contract            | Address                                    |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ npx hardhat test
 npx hardhat deploy --network rinkeby
 ```
 
+Deploying to mainnet is possible by subsituting all `--network rinkeby` arguments with `--network mainnet`.
+
 ## Upgrading
 
 Upgrading contracts that are owned by a multisig should be proposed using [Defender](https://docs.openzeppelin.com/defender/guide-upgrades)

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -17,7 +17,14 @@ module.exports = {
     },
   },
 
+  defaultNetwork: "hardhat",
+
   networks: {
+    hardhat: {},
+    mainnet: {
+      url: `https://mainnet.infura.io/v3/${process.env.INFURA_PROJECT_ID}`,
+      accounts: (process.env.DEPLOYMENT_PRIVATE_KEY === undefined) ? [] : [`${process.env.DEPLOYMENT_PRIVATE_KEY}`]
+    },
     rinkeby: {
       url: `https://rinkeby.infura.io/v3/${process.env.INFURA_PROJECT_ID}`,
       accounts: (process.env.DEPLOYMENT_PRIVATE_KEY === undefined) ? [] : [`${process.env.DEPLOYMENT_PRIVATE_KEY}`]


### PR DESCRIPTION
This change introduces the mainnet addresses of all Arrow contracts.

It also introduces mainnet as an option for Hardhat interactions.