### PR TITLE
Add cancel functionality to vesting contracts

### DIFF
--- a/contracts/ArrowVestingBase.sol
+++ b/contracts/ArrowVestingBase.sol
@@ -2,12 +2,23 @@
 pragma solidity ^0.8.11;
 
 import "@openzeppelin/contracts-upgradeable/finance/VestingWalletUpgradeable.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "./ArrowVestingFactory.sol";
 
 /** 
     @title Base implementation of vesting contract that will be cloned into individual vesting wallets pointing at specific beneficiary addresses.
     @dev Although the contract inherits an upgradeable interface, the contract itself is not intended to be upgradeable; rather, it is intended to be cloned by `ArrowVestingFactory`.
 */
 contract ArrowVestingBase is VestingWalletUpgradeable {
+
+    ArrowVestingFactory private factory;
+
+    modifier onlyFactoryOwner {
+      require(msg.sender == factory.owner(), "Not factory owner");
+      _;
+    }
 
     constructor() initializer {}
 
@@ -16,6 +27,46 @@ contract ArrowVestingBase is VestingWalletUpgradeable {
         uint64 startTimestamp,
         uint64 durationSeconds
     ) public initializer {
+        factory = ArrowVestingFactory(msg.sender);
+
         __VestingWallet_init(beneficiaryAddress, startTimestamp, durationSeconds);
+    }
+
+    /**
+        @notice Cancels the vesting contract, releasing vested ETH to the beneficiary and unvested ETH back to the factory owner.
+        
+        Can only be called by the vesting factory owner.
+    */
+    function cancel() public onlyFactoryOwner {
+        release();
+
+        Address.sendValue(payable(factory.owner()), address(this).balance);
+    }
+
+    /**
+        @notice Cancels the vesting contract, releasing vested tokens to the beneficiary and unvested tokens back to the factory owner.
+
+        @param token Address of the ERC20 token contract to be cancelled.
+        
+        Can only be called by the vesting factory owner.
+    */
+    function cancel(address token) public onlyFactoryOwner {
+        release(token);
+
+        IERC20 erc20 = IERC20(token);
+
+        SafeERC20.safeTransfer(erc20, factory.owner(), erc20.balanceOf(address(this)));
+    }
+
+    /**
+        @notice Updates the factory contract owning the vesting contract to a new address.
+        This should be called on all vesting contracts to transfer ownership of them to a new factory. 
+
+        @param newFactory Address of the new factory contract that will own the vesting contract.
+        
+        Can only be called by the vesting factory owner.
+    */
+    function updateFactory(address newFactory) public onlyFactoryOwner {
+        factory = ArrowVestingFactory(newFactory);
     }
 }

--- a/contracts/ArrowVestingFactory.sol
+++ b/contracts/ArrowVestingFactory.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.11;
 // SPDX-License-Identifier: MIT
 
 import "@openzeppelin/contracts/proxy/Clones.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "./ArrowVestingBase.sol";
 
 /**
     @title Factory contract for creating vesting wallets from their base implementations
  */
-contract ArrowVestingFactory {
+contract ArrowVestingFactory is Ownable {
     
     address public vestingImplementation;
 


### PR DESCRIPTION
This change adds the ability for an owner of vesting contracts to cancel the vesting schedule of
a token or ETH that is currently locked within it, returning unvested tokens back to the owner.

Vesting contracts retain the address of their deployer and read ownership from the factory that
deployed them, allowing one ownership transfer to effect all deployed vesting contracts.