### PR TITLE
Index vesting events by beneficiary address

### DIFF
--- a/contracts/ArrowVestingFactory.sol
+++ b/contracts/ArrowVestingFactory.sol
@@ -13,7 +13,7 @@ contract ArrowVestingFactory {
     address public vestingImplementation;
 
     event NewVestingAgreement(
-        address beneficiaryAddress,
+        address indexed beneficiaryAddress,
         uint64 startTimestamp,
         uint64 durationSeconds,
         address vestingWalletAddress


### PR DESCRIPTION
This change adds indexing to the beneficiary addresses of all
new vesting contract events, allowing them to be filtered by
each specific address.

Useful in the future to allow frontends to find all vesting
contracts for a given address.